### PR TITLE
bump version to 1.0.25 for ROCm 6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ include( ROCMClients )
 include( ROCMHeaderWrapper )
 
 # Using standardized versioning from rocm-cmake
-set ( VERSION_STRING "1.0.23" )
+set ( VERSION_STRING "1.0.25" )
 rocm_setup_version( VERSION ${VERSION_STRING} )
 
 # Append our library helper cmake path and the cmake path for hip (for

--- a/docs/.doxygen/Doxyfile
+++ b/docs/.doxygen/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "rocFFT"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = v1.0.23
+PROJECT_NUMBER         = v1.0.25
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a


### PR DESCRIPTION
This step was missed when we made the 6.0 branch.