### PR TITLE
Add -mcumode arg while compiling with hiprtc

### DIFF
--- a/library/src/rtc_compile.cpp
+++ b/library/src/rtc_compile.cpp
@@ -36,9 +36,11 @@ std::vector<char> compile_inprocess(const std::string& kernel_src, const std::st
     std::string gpu_arch_arg = "--gpu-architecture=" + gpu_arch;
 
     std::vector<const char*> options;
+    options.reserve(4);
     options.push_back("-O3");
     options.push_back("-std=c++14");
     options.push_back(gpu_arch_arg.c_str());
+    options.push_back("-mcumode");
 
     auto compileResult = hiprtcCompileProgram(prog, options.size(), options.data());
     if(compileResult != HIPRTC_SUCCESS)

--- a/library/src/rtc_test_harness_helper.cpp
+++ b/library/src/rtc_test_harness_helper.cpp
@@ -106,7 +106,9 @@ std::unique_ptr<RTCKernel> compile(const std::string& name, const std::string& s
         throw std::runtime_error("unable to create program");
     }
     std::vector<const char*> options;
+    options.reserve(2);
     options.push_back("-O3");
+    options.push_back("-mcumode");
 
     auto compileResult = hiprtcCompileProgram(prog, options.size(), options.data());
     if(compileResult != HIPRTC_SUCCESS)


### PR DESCRIPTION
This resolves some performance issues seen with Navi GPUs

Summary of proposed changes:
-  This is required due to recent change in hiprtc which removes the arg `-mcumode` added by default
- https://github.com/ROCm/clr/commit/49369f08519be2c8643736c5611c9cd77ce47b93
- This only affects Navi GPUs since gfx9 only support CU mode
