### PR TITLE
rtc: use gridDim.x for everything in real-complex kernels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Documentation for rocFFT is available at
 [https://rocm.docs.amd.com/projects/rocFFT/en/latest/](https://rocm.docs.amd.com/projects/rocFFT/en/latest/).
 
+## rocFFT 1.0.27 (unreleased)
+
+### Fixes
+
+* Fixed kernel launch failure on execute of very large odd-length real-complex transforms.
+
 ## rocFFT 1.0.26 for ROCm 6.1.0
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Documentation for rocFFT is available at
 
 * Fixed kernel launch failure on execute of very large odd-length real-complex transforms.
 
+### Additions
+
+* Enable multi-gpu testing on systems without direct GPU-interconnects
+
 ## rocFFT 1.0.26 for ROCm 6.1.0
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Documentation for rocFFT is available at
 [https://rocm.docs.amd.com/projects/rocFFT/en/latest/](https://rocm.docs.amd.com/projects/rocFFT/en/latest/).
 
-## rocFFT 1.0.27 (unreleased)
+## rocFFT 1.0.26 for ROCm 6.1.1
 
 ### Fixes
 


### PR DESCRIPTION
Fixes launch errors on very large odd-length real-complex transforms, since
gridDim.y and gridDim.z are limited to 64k.