### PR TITLE
Documentation: Remove faulty reference

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,7 @@ docs_core.run_doxygen(doxygen_root="doxygen", doxygen_path="doxygen/xml")
 docs_core.setup()
 
 external_projects_current_project = "rocfft"
+external_projects = []
 
 for sphinx_var in ROCmDocs.SPHINX_VARS:
     globals()[sphinx_var] = getattr(docs_core, sphinx_var)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,20 +15,22 @@ The code is open and hosted here: https://github.com/ROCmSoftwarePlatform/rocFFT
 
 The rocFFT documentation is structured as follows:
 
-.. card:: Conceptual
+.. grid:: 2
 
-  * :ref:`what-is-rocfft`
+    .. grid-item-card:: Conceptual
 
-.. card:: How To
+      * :ref:`what-is-rocfft`
 
-  * :ref:`working-with-rocfft`
-  * :ref:`load-store-callbacks`
-  * :ref:`runtime-compilation`
+    .. grid-item-card:: How To
 
-.. card:: API Reference
+      * :ref:`working-with-rocfft`
+      * :ref:`load-store-callbacks`
+      * :ref:`runtime-compilation`
 
-  * :ref:`api-usage`
-  * :ref:`api-reference`
+    .. grid-item-card:: API Reference
+
+      * :ref:`api-usage`
+      * :ref:`api-reference`
 
 To contribute to the documentation refer to `Contributing to ROCm  <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,17 +15,17 @@ The code is open and hosted here: https://github.com/ROCmSoftwarePlatform/rocFFT
 
 The rocFFT documentation is structured as follows:
 
-.. card:: :ref:`Conceptual`
+.. card:: Conceptual
 
   * :ref:`what-is-rocfft`
 
-.. card:: :ref:`How-To`
+.. card:: How To
 
   * :ref:`working-with-rocfft`
   * :ref:`load-store-callbacks`
   * :ref:`runtime-compilation`
 
-.. card:: :ref:`API Reference`
+.. card:: API Reference
 
   * :ref:`api-usage`
   * :ref:`api-reference`

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -7,6 +7,10 @@ subtrees:
     title: What is rocFFT?
   - file: how-to/working-with-rocfft
     title: Working with rocFFT
+  - file: how-to/runtime-compilation
+    title: Runtime Compilation
+  - file: how-to/load-store-callbacks
+    title: Load and Store Callbacks
   - file: reference/reference.rst
     title: API Reference
     subtrees:


### PR DESCRIPTION
The (develop) documentation currently faultily links to rocblas, as :ref:`How-To` is currently just a place holder, and intersphinx then starts looking for the reference in other linked projects, even if the reference isn't scoped properly.

The placeholder references are removed for now, and to avoid that problem occuring again, the `external_projects` have been set to an empty list. If rocFFTs documentation needs to link to other projects, they have to be added to that list (see [rocm-docs-core for reference](https://rocm.docs.amd.com/projects/rocm-docs-core/en/latest/developer_guide/projects_yaml.html))