### PR TITLE
Cherry pick Doc fix faulty ref (#1277)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,7 @@ docs_core.run_doxygen(doxygen_root="doxygen", doxygen_path="doxygen/xml")
 docs_core.setup()
 
 external_projects_current_project = "rocfft"
+external_projects = []
 
 for sphinx_var in ROCmDocs.SPHINX_VARS:
     globals()[sphinx_var] = getattr(docs_core, sphinx_var)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,20 +15,22 @@ The code is open and hosted here: https://github.com/ROCmSoftwarePlatform/rocFFT
 
 The rocFFT documentation is structured as follows:
 
-.. card:: :ref:`Conceptual`
+.. grid:: 2
 
-  * :ref:`what-is-rocfft`
+    .. grid-item-card:: Conceptual
 
-.. card:: :ref:`How-To`
+      * :ref:`what-is-rocfft`
 
-  * :ref:`working-with-rocfft`
-  * :ref:`load-store-callbacks`
-  * :ref:`runtime-compilation`
+    .. grid-item-card:: How To
 
-.. card:: :ref:`API Reference`
+      * :ref:`working-with-rocfft`
+      * :ref:`load-store-callbacks`
+      * :ref:`runtime-compilation`
 
-  * :ref:`api-usage`
-  * :ref:`api-reference`
+    .. grid-item-card:: API Reference
+
+      * :ref:`api-usage`
+      * :ref:`api-reference`
 
 To contribute to the documentation refer to `Contributing to ROCm  <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.
 

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -7,6 +7,10 @@ subtrees:
     title: What is rocFFT?
   - file: how-to/working-with-rocfft
     title: Working with rocFFT
+  - file: how-to/load-store-callbacks
+    title: Load and Store Callbacks
+  - file: how-to/runtime-compilation
+    title: Runtime Compilation
   - file: reference/reference.rst
     title: API Reference
     subtrees:


### PR DESCRIPTION
- Remove faulty reference and fix index reference grid from docs.

Summary of proposed changes:
-  Cherry pick fix for doc faulty link and layout of grid cards
